### PR TITLE
add ak

### DIFF
--- a/gengokit/template/NAME-service/NAME-client/client.gotemplate
+++ b/gengokit/template/NAME-service/NAME-client/client.gotemplate
@@ -96,7 +96,7 @@ func (client *Client) factory(makeEndpoint func(server pb.{{.Service.Name}}Serve
 			if err != nil {
 				return nil, nil, err
 			}
-			grpc, err := NewGrpc(transport, tracer, logger, CtxValuesToSend(""))
+			grpc, err := NewGrpc(transport, tracer, logger, CtxValuesToSend("access_key"))
 			if err != nil {
                 return nil, nil, err
             }


### PR DESCRIPTION
使用时，类似这样，ctx 会被传到 grpc server 端：
_, err := tracking_client.Instance().CreateScenario(context.WithValue(context.Background(), "access_key", token), &trackingV1.CreateScenarioRequest{
			ProductId: a.users[token].ProductID,
			TrackPoints: &hub.TrackPoints{
				TrackPoints: trackPoints,
			},
		})